### PR TITLE
Automated CI builds for Windows, macOS & Linux x64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+matrix:
+  include:
+    - os: linux
+      dist: xenial
+      dotnet: 2.2
+    - os: osx
+      dotnet: 2.2.107
+language: csharp
+solution: QuestSaberPatch.sln
+mono: none
+dotnet: 2.2
+script:
+  - dotnet publish -c Release -r "${TRAVIS_OS_NAME}-x64" --self-contained true /p:useapphost=true
+after_success:
+  - ls -lAhR
+  - mkdir -p ./dist/
+  - tar -czvf "./dist/${TRAVIS_OS_NAME}-x64.tar.gz" "./app/bin/Release/netcoreapp2.2/${TRAVIS_OS_NAME}-x64/publish"
+  - wget --method PUT --body-file="./dist/${TRAVIS_OS_NAME}-x64.tar.gz" "https://transfer.sh/questsaberpatch-${TRAVIS_OS_NAME}-x64.tar.gz" -O - -nv
+  - ls -lAhR
+

--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ It can patch a Beat Saber APK with new custom levels in the "Extras" folder, as 
 
 ### Initial setup (do this once)
 
-1. Install .NET Core: <https://dotnet.microsoft.com/download> (for my patcher) and Java (for the signer, on Windows make sure it's 64-bit Java or the signer may not work). **If you're on macOS** you may be able to avoid installing dotNET by using the self-contained release on the [Releases page](https://github.com/trishume/QuestSaberPatch/releases) and following the instructions on the release, this may not have the newest code though.
+1. Install .NET Core: <https://dotnet.microsoft.com/download> (for my patcher) and Java (for the signer, on Windows make sure it's 64-bit Java or the signer may not work). You may be able to avoid installing dotNET by using one of the self-contained releases on the [Releases page](https://github.com/trishume/QuestSaberPatch/releases) and following the instructions on the release, this may not have the newest code though.
 2. Install `adb`: <https://developer.android.com/studio/command-line/adb>
 3. Put your Oculus Quest in Developer Mode by getting your Oculus account turned into a developer account.
 4. Use `adb pull /data/app/com.beatgames.beatsaber-1/base.apk {location you want to put it}` to grab the APK off the device

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+image: Visual Studio 2017
+clone_folder: c:\projects\QuestSaberPatch
+before_build:
+  - cd c:\projects\QuestSaberPatch
+  - dotnet --version
+build_script:
+  - dotnet publish -c Release -r "win-x64" --self-contained true /p:useapphost=true
+after_build:
+  - dir /adh /s
+artifacts:
+  - path: .\app\bin\Release\netcoreapp2.2\win-x64\publish
+    type: zip


### PR DESCRIPTION
Automatically build self-contained releases using CI services.  
Windows builds use AppVeyor and are saved as a `.zip` archive build artifact.
macOS and Linux builds use Travis and are uploaded to [transfer.sh](https://transfer.sh/) as a `.tar.gz` archive.  
All builds are x64.