### PR TITLE
Port to DotNetZip

### DIFF
--- a/LibSaberPatch/LibSaberPatch.csproj
+++ b/LibSaberPatch/LibSaberPatch.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DotNetZip" Version="1.13.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NVorbis" Version="0.8.6" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />


### PR DESCRIPTION
This will hopefully help with #4 after people affected by it reset their patching APKs to an original unmodified APK. It's only ever so slightly slower, like 20s vs 17s, and peak memory usage should hopefully go down since it only opens the ogg files while it's writing them out.