### PR TITLE
Yoink for CustomText proper support (I didn't actually make it work last time)

### DIFF
--- a/LibSaberPatch/AssetDataObjects/TextAssetData.cs
+++ b/LibSaberPatch/AssetDataObjects/TextAssetData.cs
@@ -80,7 +80,7 @@ namespace LibSaberPatch.AssetDataObjects
         {
             // FOR NOW, ONLY APPLIES THE WATERMARK IN ENGLISH
             string header = "\n<size=150%><color=#EC1C24FF>Quest Modders</color></size>";
-            string testersHeader = "<color=#E543E5FF>Testers</color>";
+            string testersHeader = "<size=120%><color=#E543E5FF>Testers</color></size>";
 
             string sc2ad = "<color=#EDCE21FF>Sc2ad</color>";
             string trishume = "<color=#40E0D0FF>trishume</color>";
@@ -100,18 +100,20 @@ namespace LibSaberPatch.AssetDataObjects
             localeValues["CREDITS_CONTENT"]["ENGLISH"] = item.Remove(item.Length - 2) + message + '"';
         }
 
-        public string WriteLocaleText(Dictionary<string, Dictionary<string, string>> values)
+        public void WriteLocaleText(Dictionary<string, Dictionary<string, string>> values)
         {
             StringBuilder sb = new StringBuilder();
             foreach (string s in values.Keys) {
-                sb.Append(s);
                 foreach (string lang in values[s].Keys) {
-                    sb.AppendFormat(",{0},{1}", lang, values[s][lang]);
+                    sb.AppendFormat("{0},", values[s][lang]);
                 }
-                sb.Append('\n');
+                sb.Length--; // remove trailing comma
+                sb.Append("\r\n");
             }
             sb.Length = sb.Length - 1; // remove trailing newline
-            return sb.ToString();
+            Console.WriteLine("Writing text: " + sb.ToString());
+            Console.WriteLine(sb.ToString().Contains("Sc2ad"));
+            script = sb.ToString();
         }
     }
 }

--- a/LibSaberPatch/AssetDataObjects/TextAssetData.cs
+++ b/LibSaberPatch/AssetDataObjects/TextAssetData.cs
@@ -111,8 +111,6 @@ namespace LibSaberPatch.AssetDataObjects
                 sb.Append("\r\n");
             }
             sb.Length = sb.Length - 1; // remove trailing newline
-            Console.WriteLine("Writing text: " + sb.ToString());
-            Console.WriteLine(sb.ToString().Contains("Sc2ad"));
             script = sb.ToString();
         }
     }


### PR DESCRIPTION
It's literally like 2 commits, one of which is removing print statements I accidentally added. I still use string builder, although there could probably be a different, better way to avoid loading the entire text file and then writing the entire text file, but I'm far too lazy to implement that. Now I shall go back to implementing CustomSabers over here in my dark corner where things happen for some reason...